### PR TITLE
Template, README and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ tls-service         <none>                                    name=tls-server   
 NAME                HOST/PORT           PATH                SERVICE             LABELS
 route-passthrough   my-tls-server                           tls-service   
 
-[vagrant@openshiftdev paul_temp]$ go run client.go
+[vagrant@openshiftdev paul_temp]$ go run client.go tls-service.route.ocpmaster.com
 Hello TLS
 [vagrant@openshiftdev paul_temp]$
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Demonstrates a TLS tcp client connecting through the OpenShift router to a TLS t
 1.  Start OpenShift
 1.  Install the router
 1.  Create the pod, service, and route
-1.  Run the client and pass in route as a parameter(ie, go run client.go sni.service.com)
+1.  Run the client and pass in route as a parameter(ie, ***go run client.go sni.service.com***)
 
 If you're not using the single machine vagrant environment you may need to adjust the ip address in the client.  The client
 points to 10.0.2.15 which is the default ip for the vagrant machine and is also the entry point for the router since the

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Demonstrates a TLS tcp client connecting through the OpenShift router to a TLS t
 1.  Build the docker image with `build.sh`
 1.  Start OpenShift
 1.  Install the router
-1.  Create the pod, service, and route
+1.  Create a new app from the template
 1.  Run the client and pass in route as a parameter(ie, ***go run client.go sni.service.com***)
 
 If you're not using the single machine vagrant environment you may need to adjust the ip address in the client.  The client
@@ -13,7 +13,8 @@ points to 10.0.2.15 which is the default ip for the vagrant machine and is also 
 router binds to host ports.
 
 ```
-[vagrant@openshiftdev paul_temp]$ osc get pods && osc get services && osc get routes
+[vagrant@openshiftdev paul_temp]$ oc new-app -f snidemo-template.json 
+[vagrant@openshiftdev paul_temp]$ oc get pods && oc get services && oc get routes
 POD                 IP                  CONTAINER(S)                   IMAGE(S)                          HOST                           LABELS              STATUS
 router              172.17.0.2          origin-haproxy-router-router   openshift/origin-haproxy-router   openshiftdev.local/127.0.0.1   <none>              Running
 tls-server          172.17.0.4          tls-server                     pweil/tls-server                  openshiftdev.local/127.0.0.1   name=tls-server     Running

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Demonstrates a TLS tcp client connecting through the OpenShift router to a TLS t
 1.  Start OpenShift
 1.  Install the router
 1.  Create the pod, service, and route
-1.  Run the client
+1.  Run the client and pass in route as a parameter(ie, go run client.go sni.service.com)
 
 If you're not using the single machine vagrant environment you may need to adjust the ip address in the client.  The client
 points to 10.0.2.15 which is the default ip for the vagrant machine and is also the entry point for the router since the
@@ -24,7 +24,7 @@ tls-service         <none>                                    name=tls-server   
 NAME                HOST/PORT           PATH                SERVICE             LABELS
 route-passthrough   my-tls-server                           tls-service   
 
-[vagrant@openshiftdev paul_temp]$ go run client.go 
+[vagrant@openshiftdev paul_temp]$ go run client.go
 Hello TLS
 [vagrant@openshiftdev paul_temp]$
 ```

--- a/client.go
+++ b/client.go
@@ -9,11 +9,12 @@ import (
 )
 
 func main() {
-	server := flag.String("server", "sni.apps.josborne.com:443", "the server and port to connect to in the form of 10.0.2.15:443")
+	hostname := os.Args[1] // add some error checking
+	server := flag.String("server", hostname + ":443", "the server and port to connect to in the form of 10.0.2.15:443")
 	flag.Parse()
 
 	config := &tls.Config{
-		ServerName:         "sni.apps.josborne.com",
+		ServerName:         hostname,
 		InsecureSkipVerify: true,
 	}
 

--- a/snidemo-template.json
+++ b/snidemo-template.json
@@ -1,0 +1,93 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "snidemo"
+  },
+  "objects": [
+    {
+      "kind": "Route",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "sni-route",
+        "labels": {
+          "app": "snidemo"
+        },
+        "annotations": {
+          "openshift.io/host.generated": "true"
+        }
+      },
+      "spec": {
+        "to": {
+          "kind": "Service",
+          "name": "tls-service",
+          "weight": 100
+        },
+        "tls": {
+          "termination": "passthrough"
+        },
+        "wildcardPolicy": "None"
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "tls-service",
+        "labels": {
+          "app": "snidemo"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "sni",
+            "protocol": "TCP",
+            "port": 2999,
+            "targetPort": 9999
+          }
+        ],
+        "selector": {
+          "name": "tls-server"
+        },
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      }
+    },
+    {
+      "kind": "Pod",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "tls-server",
+        "labels": {
+          "app": "snidemo",
+          "name": "tls-server"
+        },
+        "annotations": {
+          "openshift.io/scc": "restricted"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "name": "tls-server",
+            "image": "brandoncox/tls-server",
+            "args": [
+              "/usr/sbin/server",
+              "-msg=test2"
+            ],
+            "ports": [
+              {
+                "containerPort": 9999,
+                "protocol": "TCP"
+              }
+            ],
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "dnsPolicy": "ClusterFirst"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Added a template. Uses a image on Docker Hub that I built and pushed. Hostname is generated.

Made the hostname passable via Args (I don't know GoLang so error checking is non-existent. Ill fix it when I get the chance.)